### PR TITLE
Add velocity state sensor

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,3 +1,0 @@
-[Dolphin]
-Timestamp=2019,1,18,18,34,23
-Version=4

--- a/.directory
+++ b/.directory
@@ -1,0 +1,3 @@
+[Dolphin]
+Timestamp=2019,1,18,18,34,23
+Version=4

--- a/iop_velocity_state_sensor_fkie/CMakeLists.txt
+++ b/iop_velocity_state_sensor_fkie/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8.3)
 project(iop_velocity_state_sensor_fkie)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/iop_velocity_state_sensor_fkie/CMakeLists.txt
+++ b/iop_velocity_state_sensor_fkie/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.5)
+project(iop_velocity_state_sensor_fkie)
+
+find_package(catkin REQUIRED COMPONENTS
+			 iop_component_fkie
+             iop_management_fkie
+             nav_msgs
+             roscpp
+) 
+
+iop_init(COMPONENT_ID 0)
+
+catkin_package(
+    LIBRARIES ${PROJECT_NAME}
+    CATKIN_DEPENDS
+        iop_component_fkie
+        iop_management_fkie
+        nav_msgs
+)
+
+iop_code_generator(
+  IDLS
+    urn.jaus.jss.core-v1.0/Events.xml
+    urn.jaus.jss.core-v1.0/Transport.xml
+    urn.jaus.jss.mobility/VelocityStateSensor.xml
+  OWN_IDLS
+  OVERRIDES
+    include/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h
+    src/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.cpp
+    src/main.cpp
+  EXTERN_SERVICES
+    urn_jaus_jss_core_Events
+    urn_jaus_jss_core_Transport
+  GENERATED_SOURCES cppfiles
+)
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}
+            src/VelocityStateSensorPlugin.cpp
+            ${cppfiles}
+)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}
+                      ${catkin_LIBRARIES}
+)
+
+install(
+  DIRECTORY ${IOP_INSTALL_INCLUDE_DIRS} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+  PATTERN "*.old" EXCLUDE
+  PATTERN "*.gen" EXCLUDE
+)
+
+# Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+install(
+   FILES ./plugin_iop.xml
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/iop_velocity_state_sensor_fkie/README.md
+++ b/iop_velocity_state_sensor_fkie/README.md
@@ -1,0 +1,16 @@
+This package is part of [ROS/IOP Bridge](https://github.com/fkie/iop_core/blob/master/README.md).
+
+
+## _iop_velocity_state_sensor_fkie:_ VelocityStateSensor
+
+The velocity can be obtained from ```nav_msgs::Odometry```
+
+#### Publisher:
+
+> None
+
+#### Subscriber:
+
+_odom (nav_msgs::Odometry)_
+
+> Reads the local position.

--- a/iop_velocity_state_sensor_fkie/include/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h
+++ b/iop_velocity_state_sensor_fkie/include/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h
@@ -55,7 +55,7 @@ public:
 	virtual void setupNotifications();
 
 	/// Action Methods
-	virtual void SendAction(QueryVelocityState msg, Receive::Body::ReceiveRec transportData);
+	virtual void SendAction(std::string arg0, Receive::Body::ReceiveRec transportData);
 
 
 	/// Guard Methods

--- a/iop_velocity_state_sensor_fkie/include/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h
+++ b/iop_velocity_state_sensor_fkie/include/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h
@@ -1,0 +1,81 @@
+/**
+ROS/IOP Bridge
+Copyright (c) 2017 Fraunhofer
+
+This program is dual licensed; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation, or
+enter into a proprietary license agreement with the copyright
+holder.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; or you can read the full license at
+<http://www.gnu.de/documents/gpl-2.0.html>
+*/
+
+/** \author Alexander Tiderko */
+
+#ifndef VELOCITYSTATESENSOR_RECEIVEFSM_H
+#define VELOCITYSTATESENSOR_RECEIVEFSM_H
+
+#include "JausUtils.h"
+#include "InternalEvents/InternalEventHandler.h"
+#include "Transport/JausTransport.h"
+#include "JTSStateMachine.h"
+#include "urn_jaus_jss_mobility_VelocityStateSensor/Messages/MessageSet.h"
+#include "urn_jaus_jss_mobility_VelocityStateSensor/InternalEvents/InternalEventsSet.h"
+
+#include "InternalEvents/Receive.h"
+#include "InternalEvents/Send.h"
+
+#include "urn_jaus_jss_core_Transport/Transport_ReceiveFSM.h"
+#include "urn_jaus_jss_core_Events/Events_ReceiveFSM.h"
+
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <iop_builder_fkie/timestamp.h>
+
+#include "VelocityStateSensor_ReceiveFSM_sm.h"
+
+namespace urn_jaus_jss_mobility_VelocityStateSensor
+{
+	
+class DllExport VelocityStateSensor_ReceiveFSM : public JTS::StateMachine
+{
+public:
+	VelocityStateSensor_ReceiveFSM(urn_jaus_jss_core_Transport::Transport_ReceiveFSM* pTransport_ReceiveFSM, urn_jaus_jss_core_Events::Events_ReceiveFSM* pEvents_ReceiveFSM);
+	virtual ~VelocityStateSensor_ReceiveFSM();
+	
+	/// Handle notifications on parent state changes
+	virtual void setupNotifications();
+
+	/// Action Methods
+	virtual void SendAction(QueryVelocityState msg, Receive::Body::ReceiveRec transportData);
+
+
+	/// Guard Methods
+
+	
+	
+	VelocityStateSensor_ReceiveFSMContext *context;
+	
+protected:
+
+    /// References to parent FSMs
+	urn_jaus_jss_core_Transport::Transport_ReceiveFSM* pTransport_ReceiveFSM;
+	urn_jaus_jss_core_Events::Events_ReceiveFSM* pEvents_ReceiveFSM;
+
+    ros::Subscriber p_odom_sub;
+    ReportVelocityState p_report_velocity_state;
+
+    void odomReceived(const nav_msgs::Odometry::ConstPtr& odom);
+};
+
+};
+
+#endif // VELOCITYSTATESENSOR_RECEIVEFSM_H

--- a/iop_velocity_state_sensor_fkie/package.xml
+++ b/iop_velocity_state_sensor_fkie/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+	<name>iop_velocity_state_sensor_fkie</name>
+	<version>1.0.0</version>
+	<description>Translation of the velocity state sensor service functionality to/from ROS</description>
+
+	<author>Shivesh Khaitan</author>
+	<author>Sarthak Mittal</author>
+	<maintainer email="shiveshkhaitan@gmail.com">Shivesh Khaitan</maintainer>
+	<maintainer email="sarthakmittal2608@gmail.com">Sarthak Mittal</maintainer>
+	<license>GPLv2</license>
+	<url type="website">https://github.com/fkie/iop_jaus_mobility</url>
+
+	<buildtool_depend>catkin</buildtool_depend>
+	<depend>iop_component_fkie</depend>
+	<depend>iop_management_fkie</depend>
+	<depend>nav_msgs</depend>
+	<depend>roscpp</depend>
+
+	<export>
+		<iop_component_fkie plugin="${prefix}/plugin_iop.xml" />
+	</export>
+</package>

--- a/iop_velocity_state_sensor_fkie/plugin_iop.xml
+++ b/iop_velocity_state_sensor_fkie/plugin_iop.xml
@@ -1,0 +1,10 @@
+<library path="libiop_velocity_state_sensor_fkie">
+  <class name="VelocityStateSensor" type="iop::VelocityStateSensorPlugin" base_class_type="iop::PluginInterface">
+    <description>
+      VelocityStateSensor Service Plugin
+    </description>
+    <iop_service name="VelocityStateSensor" id="urn:jaus:jss:mobility:VelocityStateSensor" version="1.0">
+      <inherits_from id="urn:jaus:jss:core:Events" min_version="1.0"/>
+    </iop_service>
+  </class>
+</library> 

--- a/iop_velocity_state_sensor_fkie/src/VelocityStateSensorPlugin.cpp
+++ b/iop_velocity_state_sensor_fkie/src/VelocityStateSensorPlugin.cpp
@@ -1,0 +1,51 @@
+/**
+ROS/IOP Bridge
+Copyright (c) 2017 Fraunhofer
+
+This program is dual licensed; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation, or
+enter into a proprietary license agreement with the copyright
+holder.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; or you can read the full license at
+<http://www.gnu.de/documents/gpl-2.0.html>
+*/
+
+/** \author Alexander Tiderko */
+
+#include <pluginlib/class_list_macros.h>
+#include "VelocityStateSensorPlugin.h"
+
+using namespace iop;
+using namespace urn_jaus_jss_mobility_VelocityStateSensor ;
+using namespace urn_jaus_jss_core_Events;
+using namespace urn_jaus_jss_core_Transport;
+
+
+VelocityStateSensorPlugin::VelocityStateSensorPlugin()
+{
+	p_my_service = NULL;
+	p_events_service = NULL;
+	p_transport_service = NULL;
+}
+
+JTS::Service* VelocityStateSensorPlugin::get_service()
+{
+	return p_my_service;
+}
+
+void VelocityStateSensorPlugin::create_service(JTS::JausRouter* jaus_router)
+{
+	p_events_service = static_cast<EventsService *>(get_base_service());
+	p_transport_service = static_cast<TransportService *>(get_base_service(2));
+	p_my_service = new VelocityStateSensorService(jaus_router, p_transport_service, p_events_service);
+}
+
+PLUGINLIB_EXPORT_CLASS(iop::VelocityStateSensorPlugin, iop::PluginInterface) 

--- a/iop_velocity_state_sensor_fkie/src/VelocityStateSensorPlugin.h
+++ b/iop_velocity_state_sensor_fkie/src/VelocityStateSensorPlugin.h
@@ -1,0 +1,52 @@
+/**
+ROS/IOP Bridge
+Copyright (c) 2017 Fraunhofer
+
+This program is dual licensed; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation, or
+enter into a proprietary license agreement with the copyright
+holder.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; or you can read the full license at
+<http://www.gnu.de/documents/gpl-2.0.html>
+*/
+
+/** \author Alexander Tiderko */
+
+#ifndef VELOCITYSTATESENSORPLUGIN_H
+#define VELOCITYSTATESENSORPLUGIN_H
+
+#include "urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensorService.h"
+#include "urn_jaus_jss_core_Events/EventsService.h"
+#include "urn_jaus_jss_core_Transport/TransportService.h"
+
+#include <iop_component_fkie/iop_plugin_interface.h>
+
+namespace iop
+{
+
+class DllExport VelocityStateSensorPlugin : public PluginInterface
+{
+public:
+	VelocityStateSensorPlugin();
+
+	JTS::Service* get_service();
+	void create_service(JTS::JausRouter* jaus_router);
+
+protected:
+	urn_jaus_jss_mobility_VelocityStateSensor::VelocityStateSensorService *p_my_service;
+	urn_jaus_jss_core_Events::EventsService *p_events_service;
+	urn_jaus_jss_core_Transport::TransportService *p_transport_service;
+
+};
+
+};
+
+#endif

--- a/iop_velocity_state_sensor_fkie/src/main.cpp
+++ b/iop_velocity_state_sensor_fkie/src/main.cpp
@@ -1,0 +1,1 @@
+// it is a library, we don't need this main

--- a/iop_velocity_state_sensor_fkie/src/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.cpp
+++ b/iop_velocity_state_sensor_fkie/src/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.cpp
@@ -67,7 +67,7 @@ void VelocityStateSensor_ReceiveFSM::setupNotifications()
 	pEvents_ReceiveFSM->get_event_handler().register_query(QueryVelocityState::ID);
 }
 
-void VelocityStateSensor_ReceiveFSM::SendAction(QueryVelocityState msg, Receive::Body::ReceiveRec transportData)
+void VelocityStateSensor_ReceiveFSM::SendAction(std::string arg0, Receive::Body::ReceiveRec transportData)
 {
 	/// Insert User Code HERE
 	ROS_DEBUG_NAMED("VelocityStateSensor", "request from %d.%d.%d",
@@ -76,7 +76,9 @@ void VelocityStateSensor_ReceiveFSM::SendAction(QueryVelocityState msg, Receive:
 									 transportData.getSrcNodeID(),
 									 transportData.getSrcComponentID());
 
-	this->sendJausMessage(p_report_velocity_state, sender);
+	if (strcmp(arg0.c_str(), "ReportVelocityState") == 0) {
+		this->sendJausMessage(p_report_velocity_state, sender);
+	}
 }
 
 void VelocityStateSensor_ReceiveFSM::odomReceived(const nav_msgs::Odometry::ConstPtr& odom)

--- a/iop_velocity_state_sensor_fkie/src/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.cpp
+++ b/iop_velocity_state_sensor_fkie/src/urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.cpp
@@ -1,0 +1,107 @@
+/**
+ROS/IOP Bridge
+Copyright (c) 2017 Fraunhofer
+
+This program is dual licensed; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation, or
+enter into a proprietary license agreement with the copyright
+holder.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; or you can read the full license at
+<http://www.gnu.de/documents/gpl-2.0.html>
+*/
+
+/** \author Alexander Tiderko */
+
+
+#include "urn_jaus_jss_mobility_VelocityStateSensor/VelocityStateSensor_ReceiveFSM.h"
+#include <iop_component_fkie/iop_config.h>
+
+
+
+using namespace JTS;
+
+namespace urn_jaus_jss_mobility_VelocityStateSensor
+{
+
+
+
+VelocityStateSensor_ReceiveFSM::VelocityStateSensor_ReceiveFSM(urn_jaus_jss_core_Transport::Transport_ReceiveFSM* pTransport_ReceiveFSM, urn_jaus_jss_core_Events::Events_ReceiveFSM* pEvents_ReceiveFSM)
+{
+
+	/*
+	 * If there are other variables, context must be constructed last so that all 
+	 * class variables are available if an EntryAction of the InitialState of the 
+	 * statemachine needs them. 
+	 */
+	context = new VelocityStateSensor_ReceiveFSMContext(*this);
+
+	this->pTransport_ReceiveFSM = pTransport_ReceiveFSM;
+	this->pEvents_ReceiveFSM = pEvents_ReceiveFSM;
+}
+
+
+
+VelocityStateSensor_ReceiveFSM::~VelocityStateSensor_ReceiveFSM() 
+{
+	delete context;
+}
+
+void VelocityStateSensor_ReceiveFSM::setupNotifications()
+{
+	pEvents_ReceiveFSM->registerNotification("Receiving_Ready", ieHandler, "InternalStateChange_To_VelocityStateSensor_ReceiveFSM_Receiving_Ready", "Events_ReceiveFSM");
+	pEvents_ReceiveFSM->registerNotification("Receiving", ieHandler, "InternalStateChange_To_VelocityStateSensor_ReceiveFSM_Receiving_Ready", "Events_ReceiveFSM");
+	registerNotification("Receiving_Ready", pEvents_ReceiveFSM->getHandler(), "InternalStateChange_To_Events_ReceiveFSM_Receiving_Ready", "VelocityStateSensor_ReceiveFSM");
+	registerNotification("Receiving", pEvents_ReceiveFSM->getHandler(), "InternalStateChange_To_Events_ReceiveFSM_Receiving", "VelocityStateSensor_ReceiveFSM");
+
+	iop::Config cfg("~VelocityStateSensor");
+	p_odom_sub = cfg.subscribe<nav_msgs::Odometry>("odom", 1, &VelocityStateSensor_ReceiveFSM::odomReceived, this);
+
+	pEvents_ReceiveFSM->get_event_handler().register_query(QueryVelocityState::ID);
+}
+
+void VelocityStateSensor_ReceiveFSM::SendAction(QueryVelocityState msg, Receive::Body::ReceiveRec transportData)
+{
+	/// Insert User Code HERE
+	ROS_DEBUG_NAMED("VelocityStateSensor", "request from %d.%d.%d",
+			  transportData.getSrcSubsystemID(), transportData.getSrcNodeID(), transportData.getSrcComponentID());
+	JausAddress sender = JausAddress(transportData.getSrcSubsystemID(),
+									 transportData.getSrcNodeID(),
+									 transportData.getSrcComponentID());
+
+	this->sendJausMessage(p_report_velocity_state, sender);
+}
+
+void VelocityStateSensor_ReceiveFSM::odomReceived(const nav_msgs::Odometry::ConstPtr& odom)
+{
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setVelocity_X(odom->twist.twist.linear.x);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setVelocity_Y(odom->twist.twist.linear.y);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setVelocity_Z(odom->twist.twist.linear.z);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setRollRate(odom->twist.twist.angular.x);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setPitchRate(odom->twist.twist.angular.y);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setYawRate(odom->twist.twist.angular.z);
+		
+	// set timestamp
+	ReportVelocityState::Body::ReportVelocityStateRec::TimeStamp ts;
+	// current date/time based on current system
+	iop::Timestamp stamp(odom->header.stamp);
+	ts.setDay(stamp.days);
+	ts.setHour(stamp.hours);
+	ts.setMinutes(stamp.minutes);
+	ts.setSeconds(stamp.seconds);
+	ts.setMilliseconds(stamp.milliseconds);
+	p_report_velocity_state.getBody()->getReportVelocityStateRec()->setTimeStamp(ts);
+	pEvents_ReceiveFSM->get_event_handler().set_report(QueryVelocityState::ID, &p_report_velocity_state);
+}
+
+
+
+
+};


### PR DESCRIPTION
Added [VelocityStateSensor](http://openjaus.com/htmlDoc/service/VelocityStateSensor.html) service which has the responsibility of reporting the instantaneous velocity of the platform. The service subscribes to "odom". On receiving a [QueryVelocityState[2404h]](http://openjaus.com/htmlDoc/triggers/QueryVelocityState-2404.html) it responds with [ReportVelocityState[4404h]](http://openjaus.com/htmlDoc/triggers/ReportVelocityState-4404.html). The package has been successfully tested on a CVT.